### PR TITLE
Add file encryption params to auth.js.example

### DIFF
--- a/auth.js.example
+++ b/auth.js.example
@@ -1,3 +1,9 @@
+
+// File encryption
+exports.fileAlgo = 'aes256';
+// For AES-256, must be 32 bytes
+exports.filePass = Buffer.from('000102030405060708090A0B0C0D0E0F000102030405060708090A0B0C0D0E0F', 'hex').toString('base64');
+
 // Discord bot tokens
 exports.release = 'RELEASE_BOT_TOKEN';
 exports.dev = 'DEV_BOT_TOKEN';


### PR DESCRIPTION
Added section for these options in the example auth.js file:
* exports.fileAlgo (Default set to "aes256")
* exports.filePass